### PR TITLE
ci: :construction_worker: migrate github action workflows away from set-output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup PNPM Cache
         uses: actions/cache@v3


### PR DESCRIPTION
# `::set-output...` no more

GitHub Actions has deprecated `::set-output` (see PBI), so this migrates them to the new `$GITHUB_OUTPUT` syntax.

> [JIRA PBI](https://uptickhq.atlassian.net/browse/TW-1161)

**Release Note:** (Internal) Migrated set-output in GitHub Actions to new syntax.
