### PR TITLE
Fix Docker build and publish step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,6 +317,7 @@ jobs:
           file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha, mode=max
+          provenance: false
           push: true
           # Default to just the git short hash. if docker-tag-latest ; also tag as the latest image
           tags: ${{inputs.docker-repository}}:${{inputs.docker-prefix && format('{0}-', inputs.docker-prefix) || ''}}${{env.GIT_SHORT_HASH}}${{inputs.docker-tag-latest && format(',{0}:latest',inputs.docker-repository)|| ''}}


### PR DESCRIPTION
When trying to use the docker image built by the pipeline for lambda it fails with this error `The image manifest or layer media type for the source image 305686791668.dkr.ecr.ap-southeast-2.amazonaws.com/auto-scheduler:main-e3745b8 is not supported.`

this always happens on the main branch for some reason as it was not encountered with the test tag but nevertheless here is the issue on github: https://github.com/docker/buildx/issues/1509#issuecomment-1378538197 https://github.com/exercism/github-actions/pull/113