### PR TITLE
chore: add secret-env injection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ on:
       checkout-ssh-key:
         description: "The ssh key if provided; to checkout the repo with"
         required: false
+      SECRET_ENV:
+        description: "A secret environment variable to faciliate passing in secrets"
+        required: false
 
     inputs:
       checkout-ref:
@@ -358,6 +361,7 @@ jobs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SECRET_ENV: ${{ secrets.SECRET_ENV }}
       run: |
         ${{ inputs.command }}
 

--- a/.github/workflows/test-command.yaml
+++ b/.github/workflows/test-command.yaml
@@ -1,0 +1,18 @@
+name: Test Command
+on:
+  pull_request: {}
+
+permissions:
+  id-token: write # Required for federated aws oidc
+  actions: read
+  contents: write # to be able to publish a GitHub release
+  issues: write # to be able to comment on released issues
+  pull-requests: write # to be able to comment on released pull requests
+
+jobs:
+  test-command:
+    uses: ./.github/workflows/ci.yaml
+    secrets:
+      SECRET_ENV: "HI"
+    with:
+      command: echo $SECRET_ENV


### PR DESCRIPTION
Adds ability to inject secrets into reusable workflows such that they can be referenced in the `command` step.

This is a github actions limitation and requires a ... workaround.

Cannot reference secrets etc in resuable workflow `with:` inputs.