### PR TITLE
Specify current directory as docker context instead of default git context

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -386,7 +386,7 @@ jobs:
       if: inputs.docker-enabled
       uses: docker/build-push-action@v6
       with:
-        context: "{{defaultContext}}:${{ inputs.docker-context }}"
+        context: "${{ inputs.docker-context }}"
         file: Dockerfile
         cache-from: type=gha
         cache-to: type=gha, mode=max


### PR DESCRIPTION
### Changes:

- Uses a specific directory for docker context instead of the default git context so that previous file mutations in previous steps wouldn't be ignored