### PR TITLE
Build docker images for graviton instances

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,7 +199,7 @@ on:
       docker-image-platforms:
         description: "A comma separated list of platform to be used for building the docker image"
         type: string
-        default: "linux/amd64"
+        default: "linux/amd64,linux/arm64"
 
       docker-push:
         description: "Whether or not to push docker images"


### PR DESCRIPTION
### Changes:

- Build images for `linux/arm64` platform to be able to use it on graviton instances